### PR TITLE
changed logical operations and replaceAll method to be compatible with node 14

### DIFF
--- a/src/component/utils/getImage.js
+++ b/src/component/utils/getImage.js
@@ -32,7 +32,11 @@ export default async function (
   src = path;
 
   rest.aspect = `${imageWidth / imageHeight}`;
-  fallbackFormat ||= imageFormat;
+  //fallbackFormat ||= imageFormat; 
+  // use if statement for node 14 compatibillity
+if (!fallbackFormat) {
+  fallbackFormat = imageFormat;
+}
 
   const [mainImage, artDirectedImages] = await Promise.all([
     getImageSources(

--- a/src/component/utils/getProcessedImage.js
+++ b/src/component/utils/getProcessedImage.js
@@ -69,8 +69,16 @@ export default async (src, configOptions, globalConfigOptions) => {
 
   configOptions = { ...globalConfigOptions, ...paramOptions, ...configOptions };
 
-  configOptions.aspect &&= `${configOptions.aspect}`;
-  configOptions.ar &&= `${configOptions.ar}`;
+  //configOptions.aspect &&= `${configOptions.aspect}`;
+  // use if statement for node 14 compatibillity
+  if (configOptions.aspect) {
+    configOptions.aspect = `${configOptions.aspect}`;
+  }
+  // configOptions.ar &&= `${configOptions.ar}`;
+  // use if statement for node 14 compatibillity
+  if (configOptions.ar) {
+    configOptions.ar = `${configOptions.ar}`;
+  }
 
   const {
     w,

--- a/src/plugin/index.js
+++ b/src/plugin/index.js
@@ -11,7 +11,7 @@ const { getLoadedImage, getTransformedImage } = await (sharp
   : import("./utils/codecs.js"));
 
 // @ts-ignore
-const cwd = process.cwd().replaceAll(`\\`, `/`);
+const cwd = process.cwd().replace(/\\/g, `/`); // change replaceAll method with replace method for node 14 compatibility
 
 let viteConfig;
 const store = new Map();


### PR DESCRIPTION
Hello, I am using [Layer0 ](https://www.layer0.co/)cli which only works on node 14. So when you run astro dev or astro build, it gives an error because ||= logical operator and .replaceAll method are not node 14 compatible.