### PR TITLE
Add plugin to exports

### DIFF
--- a/packages/astro-imagetools/package.json
+++ b/packages/astro-imagetools/package.json
@@ -6,10 +6,12 @@
   "types": "./types.d.ts",
   "exports": {
     ".": "./index.js",
+    "./package.json": "./package.json",
     "./ssr": "./ssr/index.js",
     "./api": "./api/index.js",
     "./config": "./config.mjs",
-    "./components": "./components/index.js"
+    "./components": "./components/index.js",
+    "./plugin": "./plugin/index.js"
   },
   "scripts": {
     "test": "echo \"No test specified\""


### PR DESCRIPTION
Fixes #46 

But, this still seems broken, because `astroViteConfigs.js` doesn't exist, and I have no idea what's going on.