### PR TITLE
Add node: prefix to built-in node imports

### DIFF
--- a/packages/astro-imagetools/api/renderBackgroundImage.js
+++ b/packages/astro-imagetools/api/renderBackgroundImage.js
@@ -1,5 +1,5 @@
 // @ts-check
-import crypto from "crypto";
+import crypto from "node:crypto";
 import getImage from "./utils/getImage.js";
 import getLinkElement from "./utils/getLinkElement.js";
 import getStyleElement from "./utils/getStyleElement.js";

--- a/packages/astro-imagetools/api/utils/codecs.js
+++ b/packages/astro-imagetools/api/utils/codecs.js
@@ -1,6 +1,6 @@
 // @ts-check
-import fs from "fs";
-import { extname } from "path";
+import fs from "node:fs";
+import { extname } from "node:path";
 import * as codecs from "@astropub/codecs";
 
 export async function getImageDetails(path, width, height, aspect) {

--- a/packages/astro-imagetools/api/utils/getFallbackImage.js
+++ b/packages/astro-imagetools/api/utils/getFallbackImage.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import util from "util";
+import util from "node:util";
 import potrace from "potrace";
 import getSrcset from "./getSrcset.js";
 import { sharp } from "../../utils/runtimeChecks.js";

--- a/packages/astro-imagetools/api/utils/getImage.js
+++ b/packages/astro-imagetools/api/utils/getImage.js
@@ -1,5 +1,5 @@
 // @ts-check
-import crypto from "crypto";
+import crypto from "node:crypto";
 import objectHash from "object-hash";
 import getImageSources from "./getImageSources.js";
 import getProcessedImage from "./getProcessedImage.js";

--- a/packages/astro-imagetools/api/utils/getProcessedImage.js
+++ b/packages/astro-imagetools/api/utils/getProcessedImage.js
@@ -1,14 +1,14 @@
 // @ts-check
-import fs from "fs";
-import crypto from "crypto";
-import { join, basename, extname, relative, resolve } from "path";
+import fs from "node:fs";
+import crypto from "node:crypto";
+import { join, basename, extname, relative, resolve } from "node:path";
 import {
   cwd,
   sharp,
   fsCachePath,
   supportedImageTypes,
 } from "../../utils/runtimeChecks.js";
-import { fileURLToPath } from "url";
+import { fileURLToPath } from "node:url";
 
 const { getImageDetails } = await (sharp
   ? import("./imagetools.js")

--- a/packages/astro-imagetools/integration/index.js
+++ b/packages/astro-imagetools/integration/index.js
@@ -1,7 +1,7 @@
 // @ts-check
-import fs from "fs";
-import path from "path";
-import { fileURLToPath } from "url";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import vitePluginAstroImageTools from "../plugin/index.js";
 
 const filename = fileURLToPath(import.meta.url);

--- a/packages/astro-imagetools/package.json
+++ b/packages/astro-imagetools/package.json
@@ -54,5 +54,8 @@
   },
   "devDependencies": {
     "vitest": "^0.12.4"
+  },
+  "engines": {
+    "node": ">=12.20.0 <13 || >=14.13.1"
   }
 }

--- a/packages/astro-imagetools/plugin/hooks/load.js
+++ b/packages/astro-imagetools/plugin/hooks/load.js
@@ -1,5 +1,5 @@
 // @ts-check
-import path from "path";
+import path from "node:path";
 import objectHash from "object-hash";
 import { getCachedBuffer } from "../utils/cache.js";
 import { getAssetPath, getConfigOptions } from "../utils/shared.js";

--- a/packages/astro-imagetools/plugin/hooks/transform.js
+++ b/packages/astro-imagetools/plugin/hooks/transform.js
@@ -1,6 +1,6 @@
 // @ts-check
-import path from "path";
-import crypto from "crypto";
+import path from "node:path";
+import crypto from "node:crypto";
 import MagicString from "magic-string";
 import { cwd } from "../../utils/runtimeChecks.js";
 

--- a/packages/astro-imagetools/plugin/index.js
+++ b/packages/astro-imagetools/plugin/index.js
@@ -1,8 +1,8 @@
 // @ts-check
-import fs from "fs";
-import stream from "stream";
-import { fileURLToPath } from "url";
-import { posix as path } from "path";
+import fs from "node:fs";
+import stream from "node:stream";
+import { fileURLToPath } from "node:url";
+import { posix as path } from "node:path";
 import load from "./hooks/load.js";
 import config from "./hooks/config.js";
 import transform from "./hooks/transform.js";

--- a/packages/astro-imagetools/plugin/utils/cache.js
+++ b/packages/astro-imagetools/plugin/utils/cache.js
@@ -1,6 +1,6 @@
 // @ts-check
-import fs from "fs";
-import { posix as path } from "path";
+import fs from "node:fs";
+import { posix as path } from "node:path";
 import { fsCachePath } from "../../utils/runtimeChecks.js";
 
 const copied = [];

--- a/packages/astro-imagetools/plugin/utils/codecs.js
+++ b/packages/astro-imagetools/plugin/utils/codecs.js
@@ -1,5 +1,5 @@
 // @ts-check
-import fs from "fs";
+import fs from "node:fs";
 import * as codecs from "@astropub/codecs";
 
 const resizedImages = new Map();

--- a/packages/astro-imagetools/utils/runtimeChecks.js
+++ b/packages/astro-imagetools/utils/runtimeChecks.js
@@ -1,6 +1,6 @@
 // @ts-check
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 import findCacheDir from "find-cache-dir";
 import filterConfigs from "./filterConfigs.js";
 


### PR DESCRIPTION
Added `node:` prefix to imports for built-in node modules. This reduces the risk of a module present in `node_modules` overriding the built-in imports. This should fix #56.

Node support for the prefixed imports (ESM imports) is:
* v12.20.0
* v14.13.1

[more info about node protocol imports](https://2ality.com/2021/12/node-protocol-imports.html)