### PR TITLE
Fix global config loading

### DIFF
--- a/demo/astro-imagetools.config.mjs
+++ b/demo/astro-imagetools.config.mjs
@@ -1,3 +1,5 @@
 import { defineConfig } from "astro-imagetools/config";
 
-export default defineConfig({});
+export default defineConfig({
+  breakpoints: [800, 1200],
+});

--- a/packages/astro-imagetools/package.json
+++ b/packages/astro-imagetools/package.json
@@ -43,6 +43,7 @@
     "@astropub/codecs": "0.4.4",
     "file-type": "17.1.1",
     "find-cache-dir": "3.3.2",
+    "find-up": "^6.3.0",
     "object-hash": "3.0.0",
     "potrace": "2.1.8"
   },

--- a/packages/astro-imagetools/utils/runtimeChecks.js
+++ b/packages/astro-imagetools/utils/runtimeChecks.js
@@ -1,7 +1,7 @@
 // @ts-check
 import fs from "node:fs";
 import path from "node:path";
-import { findUp } from 'find-up';
+import { findUp } from "find-up";
 import findCacheDir from "find-cache-dir";
 import filterConfigs from "./filterConfigs.js";
 
@@ -36,13 +36,14 @@ export const supportedConfigs = [
   "cacheDir"
 ];
 
-const configFile = await findUp(['astro-imagetools.config.js', 'astro-imagetools.config.mjs']);
+const configFile = await findUp([
+  "astro-imagetools.config.js",
+  "astro-imagetools.config.mjs",
+]);
 
-const configFunction = configFile
-  ? (await import(configFile))
-  : null;
+const configFunction = configFile ? await import(configFile) : null;
 
-const rawGlobalConfigOptions = configFunction.default ?? {}
+const rawGlobalConfigOptions = configFunction.default ?? {};
 
 const NonGlobalConfigOptions = ["src", "alt", "content"];
 

--- a/packages/astro-imagetools/utils/runtimeChecks.js
+++ b/packages/astro-imagetools/utils/runtimeChecks.js
@@ -1,6 +1,7 @@
 // @ts-check
 import fs from "node:fs";
 import path from "node:path";
+import { findUp } from 'find-up';
 import findCacheDir from "find-cache-dir";
 import filterConfigs from "./filterConfigs.js";
 
@@ -35,19 +36,13 @@ export const supportedConfigs = [
   "cacheDir"
 ];
 
-const importMeta = import.meta;
+const configFile = await findUp(['astro-imagetools.config.js', 'astro-imagetools.config.mjs']);
 
-// @ts-ignore
-const configFunction = importMeta.glob
-  ? Object.values(
-      // @ts-ignore
-      importMeta.glob("/astro-imagetools.config.(mjs|js)")
-    )[0]
+const configFunction = configFile
+  ? (await import(configFile))
   : null;
 
-const rawGlobalConfigOptions = configFunction
-  ? (await configFunction()).default
-  : {};
+const rawGlobalConfigOptions = configFunction.default ?? {}
 
 const NonGlobalConfigOptions = ["src", "alt", "content"];
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,7 @@ importers:
       '@astropub/codecs': 0.4.4
       file-type: 17.1.1
       find-cache-dir: 3.3.2
+      find-up: ^6.3.0
       imagetools-core: 3.0.2
       object-hash: 3.0.0
       potrace: 2.1.8
@@ -75,6 +76,7 @@ importers:
       '@astropub/codecs': 0.4.4
       file-type: 17.1.1
       find-cache-dir: 3.3.2
+      find-up: 6.3.0
       object-hash: 3.0.0
       potrace: 2.1.8
     optionalDependencies:
@@ -2383,6 +2385,14 @@ packages:
       path-exists: 4.0.0
     dev: true
 
+  /find-up/6.3.0:
+    resolution: {integrity: sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      locate-path: 7.1.0
+      path-exists: 5.0.0
+    dev: false
+
   /find-yarn-workspace-root2/1.2.16:
     resolution: {integrity: sha512-hr6hb1w8ePMpPVUK39S4RlwJzi+xPLuVuG8XlwXU3KD5Yn3qgBWVfy3AzNlDhWvE1EORCE65/Qm26rFQt3VLVA==}
     dependencies:
@@ -3088,6 +3098,13 @@ packages:
     dependencies:
       p-locate: 5.0.0
     dev: true
+
+  /locate-path/7.1.0:
+    resolution: {integrity: sha512-HNx5uOnYeK4SxEoid5qnhRfprlJeGMzFRKPLCf/15N3/B4AiofNwC/yq7VBKdVk9dx7m+PiYCJOGg55JYTAqoQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      p-locate: 6.0.0
+    dev: false
 
   /lodash/4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
@@ -3859,6 +3876,13 @@ packages:
       yocto-queue: 0.1.0
     dev: true
 
+  /p-limit/4.0.0:
+    resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      yocto-queue: 1.0.0
+    dev: false
+
   /p-locate/4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
@@ -3871,6 +3895,13 @@ packages:
     dependencies:
       p-limit: 3.1.0
     dev: true
+
+  /p-locate/6.0.0:
+    resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      p-limit: 4.0.0
+    dev: false
 
   /p-try/2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
@@ -3938,6 +3969,11 @@ packages:
   /path-exists/4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+
+  /path-exists/5.0.0:
+    resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: false
 
   /path-is-absolute/1.0.1:
     resolution: {integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18=}
@@ -5419,6 +5455,11 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+  /yocto-queue/1.0.0:
+    resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
+    engines: {node: '>=12.20'}
+    dev: false
 
   /zod/3.14.4:
     resolution: {integrity: sha512-U9BFLb2GO34Sfo9IUYp0w3wJLlmcyGoMd75qU9yf+DrdGA4kEx6e+l9KOkAlyUO0PSQzZCa3TR4qVlcmwqSDuw==}


### PR DESCRIPTION
Fixes https://github.com/RafidMuhymin/astro-imagetools/issues/53

I'm not sure how `import.meta.glob` was intended to be used here, or if this ever worked correctly in the past, but this function runs in node, which does not have access to `import.meta.glob`.  So, in order to locate the user's config files, I used a separate helper, [find-up](https://www.npmjs.com/package/find-up), to locate the files.

I also updated the demo to show that it's working correctly now.  Before the second commit in this PR, but after the global config was set with breakpoints of 800px and 1200px, one of the markdown images in the demo had this source:

<img width="811" alt="image" src="https://user-images.githubusercontent.com/4616705/168890043-f2860ca4-806f-4b36-be87-27a000be570b.png">

And, after the change to use `find-up` I see this:

<img width="804" alt="image" src="https://user-images.githubusercontent.com/4616705/168890089-a8b019d9-53e4-42fa-b727-e1de088efb39.png">

Which is correct.