### PR TITLE
Fix resolve of astroViteConfigs.js on Windows

### DIFF
--- a/packages/astro-imagetools/integration/index.js
+++ b/packages/astro-imagetools/integration/index.js
@@ -1,15 +1,12 @@
 // @ts-check
 import fs from "node:fs";
-import path from "node:path";
+import { posix as path, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import vitePluginAstroImageTools from "../plugin/index.js";
 
 const filename = fileURLToPath(import.meta.url);
 
-const astroViteConfigsPath = path.resolve(
-  filename,
-  "../../astroViteConfigs.js"
-);
+const astroViteConfigsPath = resolve(filename, "../../astroViteConfigs.js");
 
 export default {
   name: "astro-imagetools",


### PR DESCRIPTION
This fixes #63 as suggested by @AirBorne04 in https://github.com/RafidMuhymin/astro-imagetools/issues/63#issuecomment-1129669677.

Once we have a few end-to-end tests set up, the CI matrix should catch these kinds of issues.