### PR TITLE
Allow alt=""

### DIFF
--- a/packages/astro-imagetools/api/utils/getFilteredProps.test.ts
+++ b/packages/astro-imagetools/api/utils/getFilteredProps.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import getFilteredProps from "./getFilteredProps";
+
+describe("getFilteredProps", () => {
+  it("should should merge in default props", () => {
+    const result = getFilteredProps("Img", { src: "/img.jpeg", alt: "alt" });
+    expect(result).toEqual({
+      filteredProps: {
+        alt: "alt",
+        attributes: {},
+        breakpoints: undefined,
+        decoding: "async",
+        format: undefined,
+        formatOptions: {
+          tracedSVG: {
+            function: "trace",
+          },
+        },
+        layout: "constrained",
+        loading: "lazy",
+        objectFit: "cover",
+        objectPosition: "50% 50%",
+        placeholder: "blurred",
+        preload: undefined,
+        sizes: expect.any(Function),
+        src: "/img.jpeg",
+      },
+      transformConfigs: {},
+    });
+  });
+
+  it("should accept empty string for `alt` prop on Img", () => {
+    const result = getFilteredProps("Img", { src: "/img.jpeg", alt: "" });
+    expect(result).toMatchObject({
+      filteredProps: {
+        alt: "",
+      },
+    });
+  });
+
+  it("should accept empty string for `alt` prop on Picture", () => {
+    const result = getFilteredProps("Picture", { src: "/img.jpeg", alt: "" });
+    expect(result).toMatchObject({
+      filteredProps: {
+        alt: "",
+      },
+    });
+  });
+});

--- a/packages/astro-imagetools/utils/filterConfigs.js
+++ b/packages/astro-imagetools/utils/filterConfigs.js
@@ -16,7 +16,7 @@ export default function filterConfigs(
   ["Img", "Picture"].includes(type) && requiredConfigs.push("alt");
 
   requiredConfigs.forEach((key) => {
-    if (!clonedConfigs[key]) {
+    if (typeof clonedConfigs[key] === "undefined") {
       throw new Error(`The "${key}" property is required by ${type}`);
     }
   });

--- a/packages/astro-imagetools/utils/runtimeChecks.js
+++ b/packages/astro-imagetools/utils/runtimeChecks.js
@@ -43,7 +43,7 @@ const configFile = await findUp([
 
 const configFunction = configFile ? await import(configFile) : null;
 
-const rawGlobalConfigOptions = configFunction.default ?? {};
+const rawGlobalConfigOptions = configFunction?.default ?? {};
 
 const NonGlobalConfigOptions = ["src", "alt", "content"];
 

--- a/packages/astro-imagetools/utils/runtimeChecks.test.ts
+++ b/packages/astro-imagetools/utils/runtimeChecks.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("GlobalConfigOptions", () => {
+  beforeEach(() => {
+    // Need to reset the modules so that we can change the mock implementation between tests
+    vi.resetModules();
+  });
+
+  it("Should be an empty object by default, if a config file isn't found", async () => {
+    // Simulate not finding a config file
+    vi.doMock("find-up", () => {
+      return {
+        findUp: async () => undefined,
+      };
+    });
+    // Need to import this after the mocks are set up with `doMock`.
+    const { GlobalConfigOptions } = await import("./runtimeChecks");
+    expect(GlobalConfigOptions).toEqual({});
+  });
+
+  it("should return the configuration from a global config file", async () => {
+    // Find a config file, and mock the contents of that file
+    vi.doMock("find-up", () => {
+      return {
+        findUp: async () => "mockedConfigFile",
+      };
+    });
+    vi.doMock("mockedConfigFile", () => {
+      return {
+        default: { breakpoints: [800, 1200] },
+      };
+    });
+    const { GlobalConfigOptions } = await import("./runtimeChecks");
+    expect(GlobalConfigOptions).toEqual({ breakpoints: [800, 1200] });
+  });
+});


### PR DESCRIPTION
This changes the required prop check to just check for `undefined` values, instead of falsy values, which allows passing `alt=""`, or setting props to `false`.  I think the required prop check should just ensure that _some_ value is provided.

This builds on top of https://github.com/RafidMuhymin/astro-imagetools/pull/71, because the tests won't pass until that change is made.  So, that should be merged first.