### PR TITLE
Prevent placeholder from being larger than img

### DIFF
--- a/demo/src/layouts/MainLayout.astro
+++ b/demo/src/layouts/MainLayout.astro
@@ -18,6 +18,13 @@ const GitHubURL = `https://github.com/RafidMuhymin/astro-imagetools/tree/main/de
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap-reboot.min.css"
       crossorigin="anonymous"
     />
+
+    <!-- Unset bootstrap image resets -->
+    <style is:global>
+      img, svg {
+        vertical-align: unset;
+      }
+    </style>
   </head>
 
   <body>

--- a/packages/astro-imagetools/api/utils/getImgElement.js
+++ b/packages/astro-imagetools/api/utils/getImgElement.js
@@ -43,7 +43,7 @@ export default function getImgElement({
     .trim();
 
   const styleAttribute = [
-    "display: inline-block; overflow: hidden;",
+    "display: inline-block; overflow: hidden; vertical-align: middle;",
     customInlineStyles,
     layoutStyles,
   ]


### PR DESCRIPTION
Fixes https://github.com/RafidMuhymin/astro-imagetools/issues/52
Fixes #22

I was wondering why this didn't happen on the demo app, and it was because there was a bootstrap style reset being applied, which masked the issue.  I've removed those styles, to try to make the demo as "vanilla" as possible, although it definitely looks worse now.  But I think being accurate is more important, and we can clean up the styles if we want.

This applies the same fix that the reset was doing, it gives the `img` a style of `vertical-align: middle`, which avoids the `<picture>` element from being larger than the `<img>`.  See https://stackoverflow.com/a/15796465/1435658 for an explanation of why this is needed.

To verify this fixes the issue, you can checkout the first commit, open the demo, and see that the placeholder flashes in too large on the bottom.  This no longer happens after the second commit.