### PR TITLE
Improve markdown processing performance

### DIFF
--- a/packages/astro-imagetools/plugin/hooks/transform.js
+++ b/packages/astro-imagetools/plugin/hooks/transform.js
@@ -6,9 +6,8 @@ import { cwd } from "../../utils/runtimeChecks.js";
 
 const regexTestPattern =
   /<img\s+src\s*=(?:"|')([^("|')]*)(?:"|')\s*alt\s*=\s*(?:"|')([^("|')]*)(?:"|')[^>]*>/;
-
-const regexExecPattern =
-  /(?<=(?:\$\$render`.*))<img\s+src\s*=(?:"|')([^("|')]*)(?:"|')\s*alt\s*=\s*(?:"|')([^("|')]*)(?:"|')[^>]*>(?=.*`)/gs;
+const regexExecPattern = new RegExp(regexTestPattern, "gs");
+const regexRenderPattern = /\$\$render`(.*)`/gs;
 
 export default async function transform(code, id) {
   if (id.endsWith(".md") && regexTestPattern.test(code)) {
@@ -19,9 +18,13 @@ export default async function transform(code, id) {
 
     const { isSsrBuild, sourcemap } = astroViteConfigs;
 
-    let matches;
+    // Extract the "$$render`" part of the markdown string
+    const [result] = [...code.matchAll(regexRenderPattern)];
+    const [, renderString] = result;
+    const renderIndex = result.index + "$$render`".length;
 
-    if ((matches = code.matchAll(regexExecPattern)) !== null) {
+    const matches = renderString.matchAll(regexExecPattern);
+    if (matches !== null) {
       const s = new MagicString(code);
 
       const uuid = crypto.randomBytes(4).toString("hex");
@@ -44,8 +47,8 @@ export default async function transform(code, id) {
           : path.resolve(path.dirname(id), rawSrc).replace(cwd, "");
 
         s.overwrite(
-          match.index,
-          match.index + matchedText.length,
+          renderIndex + match.index,
+          renderIndex + match.index + matchedText.length,
           `\${${renderComponent}($$result, "${Picture}", ${Picture}, { "src": "${src}", "alt": "${alt}" })}`
         );
       }


### PR DESCRIPTION
Fixes https://github.com/RafidMuhymin/astro-imagetools/issues/40

I found that the cause of poor performance and high resource usage was the use of a lookbehind in the regex expression used to locate `<img>` elements in markdown.  

This PR removes the lookahead and lookbehind, and instead extracts out the `$$render` portion first, then looks through it, instead of the entire code string.  This is much more performant.  In my own project, which only has one markdown page with images in it, the overall build time went from

```
[build] 21 page(s) built in 61.67s
```

to

```
[build] 21 page(s) built in 19.37s
```