### PR TITLE
Ensure custom inline styles end with semi-colon

### DIFF
--- a/packages/astro-imagetools/api/utils/getContainerElement.js
+++ b/packages/astro-imagetools/api/utils/getContainerElement.js
@@ -30,7 +30,7 @@ export default function getContainerElement({
 
   const styleAttribute = [
     isBackgroundPicture ? "position: relative;" : "",
-    customInlineStyles ? `${customInlineStyles};` : "",
+    customInlineStyles + (customInlineStyles.endsWith(";") ? "" : ";"),
   ]
     .join(" ")
     .trim();

--- a/packages/astro-imagetools/api/utils/getContainerElement.js
+++ b/packages/astro-imagetools/api/utils/getContainerElement.js
@@ -30,7 +30,7 @@ export default function getContainerElement({
 
   const styleAttribute = [
     isBackgroundPicture ? "position: relative;" : "",
-    customInlineStyles,
+    customInlineStyles ? `${customInlineStyles};` : "",
   ]
     .join(" ")
     .trim();

--- a/packages/astro-imagetools/api/utils/getImgElement.js
+++ b/packages/astro-imagetools/api/utils/getImgElement.js
@@ -44,7 +44,7 @@ export default function getImgElement({
 
   const styleAttribute = [
     "display: inline-block; overflow: hidden;",
-    customInlineStyles,
+    customInlineStyles ? `${customInlineStyles};` : "",
     layoutStyles,
   ]
     .join(" ")

--- a/packages/astro-imagetools/api/utils/getImgElement.js
+++ b/packages/astro-imagetools/api/utils/getImgElement.js
@@ -44,7 +44,7 @@ export default function getImgElement({
 
   const styleAttribute = [
     "display: inline-block; overflow: hidden; vertical-align: middle;",
-    customInlineStyles + customInlineStyles.endsWith(";") ? ";" ? "",
+    customInlineStyles + customInlineStyles.endsWith(";") ? "" ? ";",
     layoutStyles,
   ]
     .join(" ")

--- a/packages/astro-imagetools/api/utils/getImgElement.js
+++ b/packages/astro-imagetools/api/utils/getImgElement.js
@@ -44,7 +44,7 @@ export default function getImgElement({
 
   const styleAttribute = [
     "display: inline-block; overflow: hidden; vertical-align: middle;",
-    customInlineStyles ? `${customInlineStyles};` : "",
+    customInlineStyles + customInlineStyles.endsWith(";") ? ";" ? "",
     layoutStyles,
   ]
     .join(" ")

--- a/packages/astro-imagetools/api/utils/getImgElement.js
+++ b/packages/astro-imagetools/api/utils/getImgElement.js
@@ -44,7 +44,7 @@ export default function getImgElement({
 
   const styleAttribute = [
     "display: inline-block; overflow: hidden; vertical-align: middle;",
-    customInlineStyles + customInlineStyles.endsWith(";") ? "" ? ";",
+    customInlineStyles + (customInlineStyles.endsWith(";") ? "" : ";"),
     layoutStyles,
   ]
     .join(" ")

--- a/packages/astro-imagetools/api/utils/getPictureElement.js
+++ b/packages/astro-imagetools/api/utils/getPictureElement.js
@@ -26,7 +26,7 @@ export default function getPictureElement({
     isBackgroundPicture
       ? `position: absolute; z-index: 0; width: 100%; height: 100%; display: inline-block;`
       : `position: relative; display: inline-block;`,
-    customInlineStyles ? `${customInlineStyles};` : "",
+    customInlineStyles + (customInlineStyles.endsWith(";") ? "" : ";"),
     layoutStyles,
   ]
     .join(" ")

--- a/packages/astro-imagetools/api/utils/getPictureElement.js
+++ b/packages/astro-imagetools/api/utils/getPictureElement.js
@@ -26,7 +26,7 @@ export default function getPictureElement({
     isBackgroundPicture
       ? `position: absolute; z-index: 0; width: 100%; height: 100%; display: inline-block;`
       : `position: relative; display: inline-block;`,
-    customInlineStyles,
+    customInlineStyles ? `${customInlineStyles};` : "",
     layoutStyles,
   ]
     .join(" ")


### PR DESCRIPTION
When passing some custom inline styles to an element within a component (such as `<Img>`) via the `attributes` property, for example:
```js
// imageProps defined earlier...
imageProps.attributes = {
  img: {
    style: 'color:red'
  },
};
const img = await renderImg(imageProps);
```

It is possible to cause a clash of inline styles if you forget to include a semi-colon at the end of the string. This results in the first `layoutStyles` css rule being ignored.

```html
<!-- max-width ignored -->
<img style="color: red max-width: 100%; height: auto;"/>
```

It is safer to ensure that a semi-colon is included at the end of the user-supplied style string because the browser can ignore an empty rule if the string contains consecutive semi-colons (if the user does include a trailing semi-colon).

```html
<!-- works, even if extra semi-colon inserted -->
<img style="color: red;; max-width: 100%; height: auto;"/>
```