### PR TITLE
fix: check image extensions in case-insensitive manner

### DIFF
--- a/packages/astro-imagetools/api/utils/getProcessedImage.js
+++ b/packages/astro-imagetools/api/utils/getProcessedImage.js
@@ -23,7 +23,7 @@ const throwErrorIfUnsupported = (src, ext) => {
     throw new Error(`Failed to load ${src}; Invalid image format`);
   }
 
-  if (ext && !supportedImageTypes.includes(ext)) {
+  if (ext && !supportedImageTypes.includes(ext.toLowerCase())) {
     throw new Error(
       `Failed to load ${src}; Invalid image format ${ext} or the format is not supported by astro-imagetools`
     );


### PR DESCRIPTION
This PR allows image files with uppercase file extensions (e.g. `some-file-name.JPG`) to be processed. This can be especially useful when transforming remote images where we don't have control over the filename.