### PR TITLE
Set left position of placeholder

### DIFF
--- a/packages/astro-imagetools/api/utils/getBackgroundStyles.js
+++ b/packages/astro-imagetools/api/utils/getBackgroundStyles.js
@@ -45,6 +45,7 @@ export default function getBackgroundStyles(
     .${className}::after {
       inset: 0;
       content: "";
+      left: 0;
       width: 100%;
       height: 100%;
       position: absolute;


### PR DESCRIPTION
This fixes an issue in safari 13.1 where the placeholder is shown to the right of the picture:

Before:
<img width="985" alt="image" src="https://user-images.githubusercontent.com/4616705/171259863-de87e0df-b903-4c23-b8e8-58fb19848ef6.png">

After:
<img width="987" alt="image" src="https://user-images.githubusercontent.com/4616705/171259886-9d30e848-aaaa-497c-b389-a59e35b798d3.png">
