### PR TITLE
Always show image alt tags

### DIFF
--- a/packages/astro-imagetools/api/utils/getImgElement.js
+++ b/packages/astro-imagetools/api/utils/getImgElement.js
@@ -62,7 +62,7 @@ export default function getImgElement({
   const imgElement = `<img
     ${attributesString}
     src="${src}"
-    ${alt ? `alt="${alt}"` : ""}
+    alt="${alt}"
     srcset="${srcset}"
     sizes="${imagesizes}"
     width="${sizes.width}"

--- a/packages/astro-imagetools/api/utils/getImgElement.js
+++ b/packages/astro-imagetools/api/utils/getImgElement.js
@@ -62,7 +62,7 @@ export default function getImgElement({
   const imgElement = `<img
     ${attributesString}
     src="${src}"
-    alt="${alt}"
+    ${typeof alt === "string" ? `alt="${alt}"` : ""}
     srcset="${srcset}"
     sizes="${imagesizes}"
     width="${sizes.width}"


### PR DESCRIPTION
To help with accessibility warnings, show alt tags even when empty.
According to mozilla web docs:
> The alt attribute is officially mandatory; it's meant to always be specified. If the image doesn't require a fallback (such as for an image which is decorative or an advisory icon of minimal importance), you may specify an empty string (""). 

https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/alt