### PR TITLE
Always render image alt tag property

### DIFF
--- a/packages/astro-imagetools/api/utils/getImgElement.js
+++ b/packages/astro-imagetools/api/utils/getImgElement.js
@@ -62,7 +62,7 @@ export default function getImgElement({
   const imgElement = `<img
     ${attributesString}
     src="${src}"
-    ${typeof alt === "string" ? `alt="${alt}"` : ""}
+    ${typeof alt === "string" ? `alt="${alt}"` : `alt=""`}
     srcset="${srcset}"
     sizes="${imagesizes}"
     width="${sizes.width}"

--- a/packages/astro-imagetools/api/utils/getImgElement.js
+++ b/packages/astro-imagetools/api/utils/getImgElement.js
@@ -62,7 +62,7 @@ export default function getImgElement({
   const imgElement = `<img
     ${attributesString}
     src="${src}"
-    ${typeof alt === "string" ? `alt="${alt}"` : `alt=""`}
+    alt="${typeof alt === 'string' ? alt : ''}"
     srcset="${srcset}"
     sizes="${imagesizes}"
     width="${sizes.width}"


### PR DESCRIPTION
Giving the image `alt` attribute is officially mandatory, we can make sure is always present even if empty.