### PR TITLE
Do not warn about astro-generated scoped classes

### DIFF
--- a/packages/astro-imagetools/utils/filterConfigs.js
+++ b/packages/astro-imagetools/utils/filterConfigs.js
@@ -23,11 +23,27 @@ export default function filterConfigs(
 
   Object.keys(clonedConfigs).forEach((key) => {
     if (!supportedConfigs.includes(key)) {
-      warn && printWarning({ key, type });
+      if (warn) {
+        if (key !== "class") {
+          printWarning({ key, type });
+        } else if (!onlyAstroClass(clonedConfigs[key])) {
+          printWarning({
+            message: `Do not provide a "class" directly to ${type}.  Instead, use attributes: https://astro-imagetools-docs.vercel.app/en/components/${type}#attributes`,
+          });
+        }
+      }
 
       delete clonedConfigs[key];
     }
   });
 
   return clonedConfigs;
+}
+
+/**
+ * Checks if the `class` attribute string is only an astro-generated scoped style class.
+ */
+function onlyAstroClass(classAttr) {
+  const astroClassPattern = /^astro-[0-9A-Z]{8}$/;
+  return astroClassPattern.test(classAttr);
 }

--- a/packages/astro-imagetools/utils/filterConfigs.test.js
+++ b/packages/astro-imagetools/utils/filterConfigs.test.js
@@ -1,0 +1,100 @@
+import { describe, expect, afterAll, it, vi, beforeEach } from "vitest";
+import { supportedConfigs } from "./runtimeChecks";
+import filterConfigs from "./filterConfigs";
+import printWarning from "./printWarning.js";
+
+// Workaround for https://github.com/vitest-dev/vitest/issues/855
+vi.mock("./printWarning.js", async () => {
+  return { default: vi.fn() };
+});
+
+const warningSpy = vi.mocked(printWarning);
+
+describe("filterConfigs", () => {
+  beforeEach(() => {
+    warningSpy.mockReset();
+  });
+  afterAll(() => {
+    vi.unmock("./printWarning.js");
+  });
+
+  it("should require a `src` attribute for all components", () => {
+    expect(() => {
+      filterConfigs("Img", { alt: "" }, supportedConfigs);
+    }).toThrowError('The "src" property is required by Img');
+    expect(() => {
+      filterConfigs("Picture", { alt: "" }, supportedConfigs);
+    }).toThrowError('The "src" property is required by Picture');
+    expect(() => {
+      filterConfigs("BackgroundImage", {}, supportedConfigs);
+    }).toThrowError('The "src" property is required by BackgroundImage');
+    expect(() => {
+      filterConfigs("BackgroundPicture", {}, supportedConfigs);
+    }).toThrowError('The "src" property is required by BackgroundPicture');
+    expect(() => {
+      filterConfigs("Global", {}, supportedConfigs);
+    }).not.toThrowError();
+  });
+
+  it("should require an `alt` attribute for Picture and Img, but not others", () => {
+    expect(() => {
+      filterConfigs("Img", { src: "src" }, supportedConfigs);
+    }).toThrowError('The "alt" property is required by Img');
+    expect(() => {
+      filterConfigs("Picture", { src: "src" }, supportedConfigs);
+    }).toThrowError('The "alt" property is required by Picture');
+    expect(() => {
+      filterConfigs("BackgroundImage", { src: "src" }, supportedConfigs);
+    }).not.toThrowError();
+    expect(() => {
+      filterConfigs("BackgroundPicture", { src: "src" }, supportedConfigs);
+    }).not.toThrowError();
+    expect(() => {
+      filterConfigs("Global", {}, supportedConfigs);
+    }).not.toThrowError();
+  });
+
+  it("should remove unsupported configs", () => {
+    const filteredConfig = filterConfigs("Global", { foo: "foo" }, [], {
+      warn: false,
+    });
+    const filteredConfigFooSupported = filterConfigs(
+      "Global",
+      { foo: "foo" },
+      ["foo"],
+      {
+        warn: false,
+      }
+    );
+    expect(filteredConfig).not.toContain({ foo: "foo" });
+    expect(filteredConfigFooSupported).toContain({ foo: "foo" });
+  });
+
+  it("should warn about unsupported configs", () => {
+    filterConfigs("Global", { foo: "foo" }, []);
+    expect(warningSpy).toHaveBeenCalledWith({ type: "Global", key: "foo" });
+  });
+
+  it("should warn about unsupported 'class' config", () => {
+    filterConfigs(
+      "Img",
+      { class: "astro-ASDF1234 my-class", src: "src", alt: "" },
+      supportedConfigs
+    );
+    expect(warningSpy).toHaveBeenCalledWith({
+      message:
+        'Do not provide a "class" directly to Img.  Instead, use attributes: https://astro-imagetools-docs.vercel.app/en/components/Img#attributes',
+    });
+  });
+
+  it("should not warn about astro-generated 'class' config", () => {
+    const filteredConfig = filterConfigs(
+      "Img",
+      { class: "astro-ASDF1234", src: "src", alt: "" },
+      supportedConfigs
+    );
+    expect(warningSpy).not.toHaveBeenCalled();
+    // class is still stripped out
+    expect(filteredConfig).not.toContain({ class: "astro-ASDF1234" });
+  });
+});


### PR DESCRIPTION
Fixes #49.

This adds a bit of logic to check for an astro-generated scoped style class before throwing a warning.  If it's only such a class, no warning is shown.  If the user provided their own class name(s), we'll give a bit nicer of an error message, pointing to the use of `attributes` rather than `class`.