### PR TITLE
fix #111: output generated assets

### DIFF
--- a/packages/astro-imagetools/integration/index.js
+++ b/packages/astro-imagetools/integration/index.js
@@ -43,5 +43,6 @@ export default {
         },
       });
     },
+    "astro:build:done": vitePluginAstroImageTools.closeBundle,
   },
 };


### PR DESCRIPTION
Fixes #111 .

## Context
Output of the generated assets stopped working with the latest Astro. Might be due to [Vite hooks](https://vitejs.dev/guide/api-plugin.html#universal-hooks) IDK. 

The official [@astro/image](https://github.com/withastro/astro/blob/main/packages/integrations/image/src/index.ts#L103) also uses the [`astro:build:done`](https://docs.astro.build/en/reference/integrations-reference/#astrobuilddone) build hook.

@RafidMuhymin I hope if we can merge this and release soon.