### PR TITLE
Add support for image/svg+xml

### DIFF
--- a/packages/astro-imagetools/utils/runtimeChecks.js
+++ b/packages/astro-imagetools/utils/runtimeChecks.js
@@ -24,7 +24,7 @@ export const supportedImageTypes = [
   "jpg",
   "png",
   "webp",
-  ...(sharp ? ["heic", "heif", "tiff", "gif"] : ["jxl", "wp2"]),
+  ...(sharp ? ["heic", "heif", "tiff", "gif", "xml"] : ["jxl", "wp2"]),
 ];
 
 // prettier-ignore


### PR DESCRIPTION
This change allows SVG images can be processed by astro-imagetools. (e.g. converting svg into webp etc) As the `file-type` library parse the SVG image as 'xml' extension, we should add `xml` to supportedImageTypes.