### PR TITLE
fix: responsive text sizing and optional chaining on filter()

### DIFF
--- a/docs/src/components/Header/Header.astro
+++ b/docs/src/components/Header/Header.astro
@@ -57,7 +57,7 @@ const lang = currentPage && getLanguageFromURL(currentPage);
     display: flex;
     overflow: hidden;
     width: 30px;
-    font-size: 2rem;
+    font-size: clamp(.8rem, 2.75vw, 2rem);
     flex-shrink: 0;
     font-weight: 600;
     line-height: 1;
@@ -129,13 +129,17 @@ const lang = currentPage && getLanguageFromURL(currentPage);
     flex-grow: 1;
     padding-right: 0.7rem;
     display: flex;
-    max-width: 200px;
+    max-width: 120px;
   }
 
   :global(.search-item > *) {
     flex-grow: 1;
   }
-
+  @media (min-width: 25em) {
+    .search-item {
+      max-width: 200px;
+    }
+  }
   @media (min-width: 50em) {
     .search-item {
       max-width: 400px;

--- a/docs/src/components/RightSidebar/TableOfContents.tsx
+++ b/docs/src/components/RightSidebar/TableOfContents.tsx
@@ -37,7 +37,7 @@ const TableOfContents: FunctionalComponent<{ headers: Header[] }> = ({
         </li>
 
         {(renderedHeaders || headers)
-          .filter(({ depth }) => depth > 1 && depth < 4)
+          ?.filter(({ depth }) => depth > 1 && depth < 4)
           .map(({ depth, slug, text }) => (
             <li class={`header-link depth-${depth}`}>
               <a href={`#${slug}`}>{text}</a>


### PR DESCRIPTION
fixes #138 

- Makes navbar header font-size responsive so it'll shrink down on mobile (down to 320px)
- Shrinks the search bar width on the smallest mobile sizes
- adds optional chaining to the menu bar `filter()` that was showing an error in the console