### PR TITLE
Fix for #180, where file format missing from src attr on <Img> component.

### DIFF
--- a/packages/astro-imagetools/api/renderImg.js
+++ b/packages/astro-imagetools/api/renderImg.js
@@ -74,22 +74,25 @@ export default async function renderImg(props) {
   const layoutStyles = getLayoutStyles({ layout });
 
   const sources = images.flatMap(({ sources, sizes, imagesizes }) =>
-    sources.map(({ src, srcset }) =>
-      getImgElement({
-        src,
-        alt,
-        sizes,
-        style,
-        srcset,
-        loading,
-        decoding,
-        imagesizes,
-        fadeInTransition,
-        layoutStyles,
-        imgAttributes,
-        imgClassName: className,
-      })
-    )
+    {
+      return sources.map(({ src, format, srcset }) => {
+        src = src + '.' + format;
+        return getImgElement({
+          src,
+          alt,
+          sizes,
+          style,
+          srcset,
+          loading,
+          decoding,
+          imagesizes,
+          fadeInTransition,
+          layoutStyles,
+          imgAttributes,
+          imgClassName: className,
+        })
+      });
+    }
   );
 
   const [img] = sources;


### PR DESCRIPTION
As described in #180, the `<Img>` component does not include a file format extension onto the file path of the src attribute. Browsers will render the image anyway as the correct path is included in the `srcset` attr. However, the current state is invalid, resulting in a 404 being thrown in both dev and prod. 

While this PR works as intended and addresses the issue, it may be better to forward the `format` property to `/api/renderImage.js` and do the concatenation there, as this is where the rest of the data manipulation occurs. However, that PR would affect more than one file, so this is a minimal proof of concept. 
   